### PR TITLE
fix: v4 migrating 문서내 공식문서 링크 경로 수정

### DIFF
--- a/document/v4.md
+++ b/document/v4.md
@@ -3,8 +3,8 @@
 ![스크린샷 2022-08-17 오후 2 20 01](https://user-images.githubusercontent.com/64779472/185040681-2352e8c8-b2d7-40f7-893d-3ee2270904c9.png)
 
 - TanStack Query(React Query v4)가 정식 릴리즈되면서 v3와 비교해서 주요 변경사항 정리 문서입니다.
-- [TanStack Query(React Query v4) 공식 문서](https://tanstack.com/)
-- [TanStack Query(React Query v4) migration 공식 문서](https://tanstack.com/query/v4/docs/guides/migrating-to-react-query-4)
+- [TanStack Query(React Query v4) 공식 문서](https://tanstack.com/query/v4)
+- [TanStack Query(React Query v4) migration 공식 문서](https://tanstack.com/query/v4/docs/framework/react/guides/migrating-to-react-query-4)
 
 <br />
 


### PR DESCRIPTION
"Migrating to TanStack Query(React) v4" 문서 내의 공식 문서 링크 경로를 수정하였습니다.
