### PR TITLE
docs: document v5 Markdown Emphasis text typo fix

### DIFF
--- a/document/v5.md
+++ b/document/v5.md
@@ -5,7 +5,7 @@
 ### 1. ⭐️ Supports a single signature, one object
 
 - `useQuery`, `useInfiniteQuery`, `useMutation`이 이제는 객체 형식만 지원하도록 변경되었습니다.
-- v4에서는 `useQuery(key, fn, options)`, `useQuery({ queryKey, queryFn, ...options })` 두 형태를 모두 지원했는데 이는 유지보수가 힘들고, 매개 변수 타입을 확인하기 위한 런타임 검사도 필요했기 때문에 오로지 `객체`` 형식만 지원하도록 v5에서 변경되었습니다.
+- v4에서는 `useQuery(key, fn, options)`, `useQuery({ queryKey, queryFn, ...options })` 두 형태를 모두 지원했는데 이는 유지보수가 힘들고, 매개 변수 타입을 확인하기 위한 런타임 검사도 필요했기 때문에 오로지 `객체` 형식만 지원하도록 v5에서 변경되었습니다.
 
 ```diff
 - useQuery(key, fn, options)


### PR DESCRIPTION
'객체'' -> '객체' Markdown Emphasis 오타로 적용 안 되어 있는 부분 적용했습니다~!